### PR TITLE
redirect to the UK website inside the GEOIP setup

### DIFF
--- a/www_personalgenomes_org/views.py
+++ b/www_personalgenomes_org/views.py
@@ -50,7 +50,7 @@ def index(request):
     if country_code == 'CA':
         return render(request, 'canada/index.html')
     elif country_code == 'GB':
-        return render(request, 'uk/index.html')
+        return redirect('https://www.personalgenomes.org.uk')
     elif country_code == 'US':
         return render(request, 'harvard/index.html')
     elif country_code == 'AT':


### PR DESCRIPTION
Further to #26 

Adds a redirection in the GeoIP setup. This is required so that `/` redirects to the correct page in the UK (at the moment `/` currently gives a server error and all other pages )...

cc @jherrero @madprime 