### PR TITLE
fix typo in deploy.sh

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -2,7 +2,7 @@
 set -e # exit with nonzero exit code if anything fails
 
 # Installing via gem file to use Netlify's Cache
-gem install jekyll
+# bundle install
 
-# jekyll build
+jekyll build
 mv _redirects _site


### PR DESCRIPTION
Hey @madprime,

Fixed a typo 👍 

I suspect the build was failing because Jekyll build was not being run and as such a _site folder was not being created...

I have this working with Netlify -  https://personalgenomes.netlify.com. This should automatically redirect if you have an ip that falls into one of the countries listed in the redirects folder. Here are the settings that I'm using: 

![site_settings__personalgenomes](https://user-images.githubusercontent.com/5578375/31935945-068765f4-b8a8-11e7-9e79-e52cf7e45eef.png)

Netlify automatically runs `gem install bundle; bundle install` and then stores the installed gems in its dependency cache. In the next build, netlify uses this dependency cache to speed up the build (by not installing dependencies again). 

I would suggest that, after merging this PR, to trigger a manual rebuild on Netlify in order to clear the build cache and thereby force netlify to reinstall dependencies:

![deploys__personalgenomes](https://user-images.githubusercontent.com/5578375/31936050-58f4a180-b8a8-11e7-89ac-a06927c7985d.png)

Lastly, can you provision a SSL and (once it's working) force TLS connection (301 redirect from http:// to https://). This can be done via the Settings page, and then clicking on the `Domain management` tab

